### PR TITLE
feat(app): 统一表格排版并同步开单销售记录

### DIFF
--- a/backend/app/orders/service.py
+++ b/backend/app/orders/service.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 
 from sqlmodel import Session, col, func, select
 
@@ -9,6 +10,7 @@ from app.orders.models import (
     SalesOrderUpdate,
 )
 from app.orders.images import store_order_item_image
+from app.sales.models import SalesRecord
 
 
 def _generate_order_number(session: Session, sales_date: date) -> str:
@@ -46,6 +48,62 @@ def get_order(session: Session, order_id: int) -> SalesOrder | None:
     return session.get(SalesOrder, order_id)
 
 
+def _calc_order_total(items: list[SalesOrderItem]) -> Decimal:
+    return sum(
+        (
+            Decimal(item.total_boxes)
+            * Decimal(item.per_box_qty)
+            * Decimal(str(item.unit_price))
+        )
+        for item in items
+    )
+
+
+def _build_order_product_summary(items: list[SalesOrderItem]) -> str:
+    names = [item.product_name.strip() for item in items if item.product_name.strip()]
+    if not names:
+        return "销售单商品"
+    if len(names) == 1:
+        return names[0]
+    return f"{names[0]} 等{len(names)}项"
+
+
+def _build_order_sales_notes(order: SalesOrder) -> str:
+    parts = [f"开单单号：{order.order_number}"]
+    if order.notes.strip():
+        parts.append(order.notes.strip())
+    return "\n".join(parts)
+
+
+def _sync_sales_record_for_order(session: Session, order: SalesOrder) -> None:
+    total_amount = _calc_order_total(order.items)
+    product_summary = _build_order_product_summary(order.items)
+
+    if order.sales_record_id:
+        record = session.get(SalesRecord, order.sales_record_id)
+    else:
+        record = None
+
+    if not record:
+        record = SalesRecord()
+
+    record.sale_time = order.sales_date
+    record.customer_name = order.customer_name
+    record.product = product_summary
+    record.amount = total_amount
+    record.delivery_time = order.delivery_date
+    record.collection_time = None
+    record.is_settled = False
+    record.payment_method = order.payment_terms
+    # 开单流程没有成本字段，先以金额兜底避免自动生成错误利润，后续可在销售记录中补充。
+    record.cost = total_amount
+    record.notes = _build_order_sales_notes(order)
+
+    session.add(record)
+    session.flush()
+    order.sales_record_id = record.id
+
+
 def create_order(session: Session, data: SalesOrderCreate) -> SalesOrder:
     order = SalesOrder(
         customer_name=data.customer_name,
@@ -70,6 +128,8 @@ def create_order(session: Session, data: SalesOrderCreate) -> SalesOrder:
         order.items.append(item)
 
     session.add(order)
+    session.flush()
+    _sync_sales_record_for_order(session, order)
     session.commit()
     session.refresh(order)
     return order
@@ -104,6 +164,8 @@ def update_order(
         order.items.append(SalesOrderItem(**item_payload))
 
     session.add(order)
+    session.flush()
+    _sync_sales_record_for_order(session, order)
     session.commit()
     session.refresh(order)
     return order
@@ -113,6 +175,8 @@ def delete_order(session: Session, order_id: int) -> bool:
     order = session.get(SalesOrder, order_id)
     if not order:
         return False
+    if order.sales_record_id and (record := session.get(SalesRecord, order.sales_record_id)):
+        session.delete(record)
     session.delete(order)
     session.commit()
     return True

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 }
+
+.ant-table-cell .ant-space {
+  flex-wrap: nowrap;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -77,7 +77,7 @@ export default function Dashboard() {
   if (!data) return null;
 
   const salesColumns = [
-    { title: "时间", dataIndex: "sale_time", key: "sale_time" },
+    { title: "时间", dataIndex: "sale_time", key: "sale_time", width: 120 },
     { title: "客户", dataIndex: "customer_name", key: "customer_name" },
     { title: "产品", dataIndex: "product", key: "product" },
     {
@@ -96,7 +96,7 @@ export default function Dashboard() {
   ];
 
   const purchaseColumns = [
-    { title: "时间", dataIndex: "purchase_time", key: "purchase_time" },
+    { title: "时间", dataIndex: "purchase_time", key: "purchase_time", width: 120 },
     { title: "厂家", dataIndex: "supplier_name", key: "supplier_name" },
     { title: "货物", dataIndex: "product_name", key: "product_name" },
     {

--- a/frontend/src/pages/Purchases.tsx
+++ b/frontend/src/pages/Purchases.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Button,
   Card,
@@ -10,11 +10,16 @@ import {
   Modal,
   Popconfirm,
   Space,
-  Tag,
   Table,
   Typography,
 } from "antd";
-import { PlusOutlined } from "@ant-design/icons";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  EyeOutlined,
+  PlusOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import dayjs from "dayjs";
 import {
@@ -133,16 +138,6 @@ export default function Purchases() {
     fetchData(filters);
   };
 
-  const totalAmount = useMemo(
-    () => data.reduce((sum, r) => sum + Number(r.total_amount), 0),
-    [data],
-  );
-  const settledCount = useMemo(() => data.filter((item) => item.is_settled).length, [data]);
-  const unsettledCount = useMemo(
-    () => data.filter((item) => !item.is_settled).length,
-    [data],
-  );
-
   const columns: ColumnsType<PurchaseOrder> = [
     {
       title: "时间",
@@ -195,12 +190,11 @@ export default function Purchases() {
       render: (v: number) => `¥${Number(v).toFixed(2)}`,
     },
     {
-      title: "结清状态",
-      dataIndex: "is_settled",
+      title: "已结金额",
+      dataIndex: "paid_amount",
       width: 110,
-      align: "center",
-      render: (value: boolean) =>
-        value ? <Tag color="green">已结清</Tag> : <Tag color="orange">未结清</Tag>,
+      align: "right",
+      render: (value: number) => `¥${Number(value).toFixed(2)}`,
     },
     {
       title: "备注",
@@ -210,13 +204,25 @@ export default function Purchases() {
     },
     {
       title: "操作",
-      width: 180,
+      key: "actions",
+      width: 220,
+      fixed: "right",
       render: (_, record) => (
-        <Space>
-          <a onClick={() => openSupplierHistory(record.supplier_name)}>厂家历史</a>
-          <a onClick={() => openEdit(record)}>编辑</a>
+        <Space size="small">
+          <Button
+            size="small"
+            icon={<EyeOutlined />}
+            onClick={() => openSupplierHistory(record.supplier_name)}
+          >
+            查看
+          </Button>
+          <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(record)}>
+            编辑
+          </Button>
           <Popconfirm title="确认删除？" onConfirm={() => handleDelete(record.id)}>
-            <a style={{ color: "#ff4d4f" }}>删除</a>
+            <Button size="small" danger icon={<DeleteOutlined />}>
+              删除
+            </Button>
           </Popconfirm>
         </Space>
       ),
@@ -225,25 +231,18 @@ export default function Purchases() {
 
   return (
     <div>
-      <Typography.Title level={4}>采购单</Typography.Title>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 16 }}>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          采购单
+        </Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+          新增采购
+        </Button>
+      </div>
 
       <FilterBar onSearch={handleSearch} />
 
-      <Card
-        title={`共 ${data.length} 条记录`}
-        extra={
-          <Space>
-            <Typography.Text type="secondary">
-              已结清 {settledCount} 条 / 未结清 {unsettledCount} 条
-            </Typography.Text>
-            <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
-              新增采购
-            </Button>
-          </Space>
-        }
-        style={{ marginTop: 16 }}
-        styles={{ header: { whiteSpace: "nowrap" } }}
-      >
+      <Card style={{ marginTop: 16 }}>
         <Table
           rowKey="id"
           columns={columns}
@@ -251,22 +250,6 @@ export default function Purchases() {
           loading={loading}
           pagination={{ pageSize: 20, showTotal: (t) => `共 ${t} 条` }}
           scroll={{ x: 1380 }}
-          summary={() => (
-            <Table.Summary fixed>
-              <Table.Summary.Row>
-                <Table.Summary.Cell index={0} colSpan={7} align="right">
-                  <strong>合计金额</strong>
-                </Table.Summary.Cell>
-                <Table.Summary.Cell index={7} align="right">
-                  <strong>¥{totalAmount.toFixed(2)}</strong>
-                </Table.Summary.Cell>
-                <Table.Summary.Cell index={8} align="center">
-                  <strong>{settledCount} / {unsettledCount}</strong>
-                </Table.Summary.Cell>
-                <Table.Summary.Cell index={9} colSpan={2} />
-              </Table.Summary.Row>
-            </Table.Summary>
-          )}
         />
       </Card>
 
@@ -323,12 +306,11 @@ function SupplierHistoryModal({
       render: (value: number) => `¥${Number(value).toFixed(2)}`,
     },
     {
-      title: "结清状态",
-      dataIndex: "is_settled",
-      width: 110,
-      align: "center",
-      render: (value: boolean) =>
-        value ? <Tag color="green">已结清</Tag> : <Tag color="orange">未结清</Tag>,
+      title: "已结多少钱",
+      dataIndex: "paid_amount",
+      width: 120,
+      align: "right",
+      render: (value: number) => `¥${Number(value).toFixed(2)}`,
     },
     { title: "备注", dataIndex: "notes", width: 220, ellipsis: true },
   ];
@@ -391,6 +373,7 @@ function FilterBar({
       <Space wrap>
         <Input
           placeholder="厂家名称"
+          prefix={<SearchOutlined />}
           value={supplier}
           onChange={(e) => setSupplier(e.target.value)}
           onPressEnter={handleSearch}
@@ -399,6 +382,7 @@ function FilterBar({
         />
         <Input
           placeholder="货物名称"
+          prefix={<SearchOutlined />}
           value={product}
           onChange={(e) => setProduct(e.target.value)}
           onPressEnter={handleSearch}
@@ -406,6 +390,8 @@ function FilterBar({
           style={{ width: 180 }}
         />
         <RangePicker
+          allowClear
+          placeholder={["开始日期", "结束日期"]}
           value={dates as [dayjs.Dayjs, dayjs.Dayjs] | null}
           onChange={(val) =>
             setDates(val as [dayjs.Dayjs | null, dayjs.Dayjs | null] | null)

--- a/frontend/src/pages/SalesRecords.tsx
+++ b/frontend/src/pages/SalesRecords.tsx
@@ -16,7 +16,12 @@ import {
   Typography,
   message,
 } from "antd";
-import { PlusOutlined, SearchOutlined } from "@ant-design/icons";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import dayjs from "dayjs";
 import { useSearchParams } from "react-router-dom";
@@ -24,7 +29,6 @@ import {
   salesApi,
   type SalesRecord,
   type SalesRecordForm,
-  type SalesSummary,
 } from "../api/sales";
 
 const { RangePicker } = DatePicker;
@@ -32,7 +36,6 @@ const { RangePicker } = DatePicker;
 export default function SalesRecords() {
   const [searchParams] = useSearchParams();
   const [records, setRecords] = useState<SalesRecord[]>([]);
-  const [summary, setSummary] = useState<SalesSummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -40,6 +43,7 @@ export default function SalesRecords() {
 
   const [customerName, setCustomerName] = useState("");
   const [isSettled, setIsSettled] = useState<boolean | undefined>();
+  const [isDueCollection, setIsDueCollection] = useState<boolean | undefined>();
   const [dateRange, setDateRange] = useState<
     [dayjs.Dayjs, dayjs.Dayjs] | null
   >(null);
@@ -49,37 +53,44 @@ export default function SalesRecords() {
     const dueParam = searchParams.get("due");
     if (settledParam === "unsettled" || dueParam === "collection") {
       setIsSettled(false);
+    } else {
+      setIsSettled(undefined);
     }
+    setIsDueCollection(dueParam === "collection" ? true : undefined);
   }, [searchParams]);
 
   const buildParams = useCallback(() => {
     const params: Record<string, unknown> = {};
     if (customerName) params.customer_name = customerName;
     if (isSettled !== undefined) params.is_settled = isSettled;
-    if (searchParams.get("due") === "collection") params.due_collection = true;
+    if (isDueCollection) params.due_collection = true;
     if (dateRange) {
       params.start_date = dateRange[0].format("YYYY-MM-DD");
       params.end_date = dateRange[1].format("YYYY-MM-DD");
     }
     return params;
-  }, [customerName, isSettled, dateRange, searchParams]);
+  }, [customerName, isSettled, isDueCollection, dateRange]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
       const params = buildParams();
-      const [listRes, summaryRes] = await Promise.all([
-        salesApi.list(params),
-        salesApi.summary(params),
-      ]);
+      const listRes = await salesApi.list(params);
       setRecords(listRes.data);
-      setSummary(summaryRes.data);
     } catch {
       message.error("加载数据失败");
     } finally {
       setLoading(false);
     }
   }, [buildParams]);
+
+  const handleResetFilters = () => {
+    const dueParam = searchParams.get("due");
+    setCustomerName("");
+    setDateRange(null);
+    setIsSettled(dueParam === "collection" ? false : undefined);
+    setIsDueCollection(dueParam === "collection" ? true : undefined);
+  };
 
   useEffect(() => {
     fetchData();
@@ -137,20 +148,20 @@ export default function SalesRecords() {
   };
 
   const columns: ColumnsType<SalesRecord> = [
-    { title: "时间", dataIndex: "sale_time", width: 110 },
+    { title: "时间", dataIndex: "sale_time", width: 120 },
     { title: "客户名称", dataIndex: "customer_name", width: 120 },
     { title: "产品", dataIndex: "product", width: 120 },
     {
       title: "金额",
       dataIndex: "amount",
-      width: 100,
+      width: 110,
       align: "right",
       render: (v: number | string) => `¥${Number(v).toFixed(2)}`,
     },
     {
       title: "收货时间",
       dataIndex: "delivery_time",
-      width: 110,
+      width: 120,
       render: (v: string) => v || "-",
     },
     {
@@ -176,34 +187,43 @@ export default function SalesRecords() {
     {
       title: "成本",
       dataIndex: "cost",
-      width: 100,
+      width: 110,
       align: "right",
       render: (v: number | string) => `¥${Number(v).toFixed(2)}`,
     },
     {
       title: "毛利润",
       dataIndex: "gross_profit",
-      width: 100,
+      width: 110,
       align: "right",
       render: (v: number | string) => `¥${Number(v).toFixed(2)}`,
     },
     {
       title: "利润率",
       dataIndex: "profit_margin",
-      width: 90,
+      width: 100,
       align: "right",
       render: (v: number | string) => `${Number(v).toFixed(2)}%`,
     },
-    { title: "备注", dataIndex: "notes", ellipsis: true },
+    {
+      title: "备注",
+      dataIndex: "notes",
+      width: 220,
+      ellipsis: true,
+    },
     {
       title: "操作",
-      width: 120,
+      width: 110,
       fixed: "right",
       render: (_, record) => (
         <Space size="small">
-          <a onClick={() => handleEdit(record)}>编辑</a>
+          <Button size="small" icon={<EditOutlined />} onClick={() => handleEdit(record)}>
+            编辑
+          </Button>
           <Popconfirm title="确认删除？" onConfirm={() => handleDelete(record.id)}>
-            <a style={{ color: "#ff4d4f" }}>删除</a>
+            <Button size="small" danger icon={<DeleteOutlined />}>
+              删除
+            </Button>
           </Popconfirm>
         </Space>
       ),
@@ -212,7 +232,14 @@ export default function SalesRecords() {
 
   return (
     <div>
-      <Typography.Title level={4}>销售记录</Typography.Title>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 16 }}>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          销售记录
+        </Typography.Title>
+        <Button type="primary" icon={<PlusOutlined />} onClick={handleAdd}>
+          新增销售记录
+        </Button>
+      </div>
 
       <Card style={{ marginBottom: 16 }}>
         <Space wrap>
@@ -236,7 +263,19 @@ export default function SalesRecords() {
               { label: "未结清", value: false },
             ]}
           />
+          <Select
+            placeholder="是否到期"
+            allowClear
+            value={isDueCollection}
+            onChange={(v) => setIsDueCollection(v)}
+            style={{ width: 120 }}
+            options={[
+              { label: "已到期", value: true },
+            ]}
+          />
           <RangePicker
+            allowClear
+            placeholder={["开始日期", "结束日期"]}
             value={dateRange}
             onChange={(dates) =>
               setDateRange(dates as [dayjs.Dayjs, dayjs.Dayjs] | null)
@@ -245,9 +284,7 @@ export default function SalesRecords() {
           <Button type="primary" onClick={fetchData}>
             查询
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={handleAdd}>
-            新增
-          </Button>
+          <Button onClick={handleResetFilters}>重置</Button>
         </Space>
       </Card>
 
@@ -257,39 +294,12 @@ export default function SalesRecords() {
           columns={columns}
           dataSource={records}
           loading={loading}
-          scroll={{ x: 1300 }}
+          scroll={{ x: 1490 }}
           pagination={{
             pageSize: 20,
             showSizeChanger: true,
             showTotal: (t) => `共 ${t} 条`,
           }}
-          summary={() =>
-            summary ? (
-              <Table.Summary fixed>
-                <Table.Summary.Row>
-                  <Table.Summary.Cell index={0} colSpan={3}>
-                    <strong>合计</strong>
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={3} align="right">
-                    <strong>¥{Number(summary.total_amount).toFixed(2)}</strong>
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={4} colSpan={4} />
-                  <Table.Summary.Cell index={8} align="right">
-                    <strong>¥{Number(summary.total_cost).toFixed(2)}</strong>
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={9} align="right">
-                    <strong>¥{Number(summary.total_profit).toFixed(2)}</strong>
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={10} align="right">
-                    <strong>{Number(summary.avg_margin).toFixed(2)}%</strong>
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={11} colSpan={2}>
-                    未结清: {summary.unsettled_count} 笔
-                  </Table.Summary.Cell>
-                </Table.Summary.Row>
-              </Table.Summary>
-            ) : null
-          }
         />
       </Card>
 


### PR DESCRIPTION
## 变更内容
- 统一销售记录、采购单、首页相关表格的排版和列宽，优化时间列、金额列、备注列与操作列的展示
- 调整销售记录与采购单筛选交互，补充到期筛选与重置能力
- 开单后自动同步生成销售记录，并在编辑、删除销售单时保持联动

## 变更原因
- 解决多个业务页面表格排版不一致、列宽不稳定、横向滚动体验不统一的问题
- 避免开单数据与销售记录分离，减少重复录入

## 验证
- `pnpm build`
- `uv run python -m compileall app`