### PR TITLE
fix(orders): 调整开单图片存储路径

### DIFF
--- a/backend/app/orders/images.py
+++ b/backend/app/orders/images.py
@@ -17,7 +17,7 @@ def _relative_image_path(order_number: str, product_name: str, item_index: int, 
     safe_order = _safe_segment(order_number, "order")
     safe_product = _safe_segment(product_name, f"item-{item_index + 1}")
     filename = f"{safe_product}{suffix}"
-    return Path("img") / safe_order / safe_product / filename
+    return Path("img") / safe_order / filename
 
 
 def store_order_item_image(image: str, order_number: str, product_name: str, item_index: int) -> str:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
         target: "http://127.0.0.1:18234",
         changeOrigin: true,
       },
+      "/img": {
+        target: "http://127.0.0.1:18234",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## 变更说明
- 将开单图片存储路径从  调整为 
- 保留前端开发环境  代理，确保编辑后图片可正常预览

## 验证
- 
> frontend@0.0.0 build /Users/aming/project/sis-book/frontend
> tsc -b && vite build

vite v8.0.8 building client environment for production...
[2Ktransforming...✓ 3075 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     0.46 kB │ gzip:   0.32 kB
dist/assets/index-MN1OwhmK.css      0.15 kB │ gzip:   0.14 kB
dist/assets/index-OizBKchJ.js   1,385.01 kB │ gzip: 425.04 kB

✓ built in 329ms
- Listing 'backend/app/orders'...
Can't list 'backend/app/orders'
